### PR TITLE
Fix/flip default

### DIFF
--- a/modules/atomic-structures/protein-dna/protein-dna.html
+++ b/modules/atomic-structures/protein-dna/protein-dna.html
@@ -218,7 +218,7 @@
           <a-entity
             id="protA"
             gltf-model="#prot"
-            scale="-2 2 2"
+            scale="2 2 2"
             rotation="90 0 0"
             position="0 0 0"
             visible="true"
@@ -266,7 +266,7 @@
           <a-entity
             id="protB"
             gltf-model="#prot"
-            scale="-2 2 2"
+            scale="2 2 2"
             rotation="90 0 0"
             position="0 0 0"
             visible="true"
@@ -314,7 +314,7 @@
           <a-entity
             id="dnaA"
             gltf-model="#dna"
-            scale="-2 2 2"
+            scale="2 2 2"
             rotation="90 0 0"
             position="0 0 0"
             visible="true"
@@ -354,7 +354,7 @@
           <a-entity
             id="dnaB"
             gltf-model="#dna"
-            scale="-2 2 2"
+            scale="2 2 2"
             rotation="90 0 0"
             position="0 0 0"
             visible="true"

--- a/modules/atomic-structures/secondary-structures/secondary-structures.html
+++ b/modules/atomic-structures/secondary-structures/secondary-structures.html
@@ -284,7 +284,7 @@
           <a-entity
             id="sticks1A"
             gltf-model="#hlx_sticks"
-            scale="2 2 -2"
+            scale="2 2 2"
             rotation="0 0 90"
             position="0 0 0"
             visible="true"
@@ -292,7 +292,7 @@
           <a-entity
             id="cartoon1A"
             gltf-model="#hlx_cartoon"
-            scale="2 2 -2"
+            scale="2 2 2"
             rotation="0 0 90"
             position="0 0 0"
             visible="true"
@@ -300,7 +300,7 @@
           <a-entity
             id="bonds1A"
             obj-model="obj: #hlx_hbonds_obj; mtl: #hlx_hbonds_mtl"
-            scale="2 2 2"
+            scale="2 2 -2"
             rotation="0 0 90"
             position="0 0 0"
             visible="true"
@@ -319,7 +319,7 @@
           <a-entity
             id="sticks1B"
             gltf-model="#hlx_sticks"
-            scale="2 2 -2"
+            scale="2 2 2"
             rotation="0 0 90"
             position="0 0 0"
             visible="true"
@@ -327,7 +327,7 @@
           <a-entity
             id="cartoon1B"
             gltf-model="#hlx_cartoon"
-            scale="2 2 -2"
+            scale="2 2 2"
             rotation="0 0 90"
             position="0 0 0"
             visible="true"
@@ -335,7 +335,7 @@
           <a-entity
             id="bonds1B"
             obj-model="obj: #hlx_hbonds_obj; mtl: #hlx_hbonds_mtl"
-            scale="2 2 2"
+            scale="2 2 -2"
             rotation="0 0 90"
             position="0 0 0"
             visible="true"
@@ -354,7 +354,7 @@
           <a-entity
             id="sticks2A"
             gltf-model="#sht_sticks"
-            scale="2 2 -2"
+            scale="2 2 2"
             rotation="90 0 45"
             position="0 0 0"
             visible="true"
@@ -362,7 +362,7 @@
           <a-entity
             id="cartoon2A"
             gltf-model="#sht_cartoon"
-            scale="2 2 -2"
+            scale="2 2 2"
             rotation="90 0 45"
             position="0 0 0"
             visible="true"
@@ -370,7 +370,7 @@
           <a-entity
             id="bonds2A"
             obj-model="obj: #sht_hbonds_obj; mtl: #sht_hbonds_mtl"
-            scale="2 2 2"
+            scale="2 2 -2"
             rotation="90 0 45"
             position="0 0 0"
             visible="true"
@@ -389,7 +389,7 @@
           <a-entity
             id="sticks2B"
             gltf-model="#sht_sticks"
-            scale="2 2 -2"
+            scale="2 2 2"
             rotation="90 0 45"
             position="0 0 0"
             visible="true"
@@ -397,7 +397,7 @@
           <a-entity
             id="cartoon2B"
             gltf-model="#sht_cartoon"
-            scale="2 2 -2"
+            scale="2 2 2"
             rotation="90 0 45"
             position="0 0 0"
             visible="true"
@@ -405,7 +405,7 @@
           <a-entity
             id="bonds2B"
             obj-model="obj: #sht_hbonds_obj; mtl: #sht_hbonds_mtl"
-            scale="2 2 2"
+            scale="2 2 -2"
             rotation="90 0 45"
             position="0 0 0"
             visible="true"

--- a/modules/utils/aframe/flip.js
+++ b/modules/utils/aframe/flip.js
@@ -10,7 +10,7 @@ AFRAME.registerComponent("listen-to-flip", {
       this.flip();
     });
 
-    if (window.innerWidth <= 768) {
+    if (window.innerWidth >= 768) {
       this.flip();
     }
   },


### PR DESCRIPTION
Fixed the original bug. Secondary structures and Prot-DNA activites had negative scale in one axis, causing the original mirror issue. Now I removed this negative scale (Adjusted the orignal part which actually needed it) and fixed overall default flip state.